### PR TITLE
Little fix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ Usage with [PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted
 ```json
 {
 	"require": {
-		"psr/log": "1.*",
 		"analog/analog": "dev-master"
 	}
 }


### PR DESCRIPTION
No need to specify psr/log in composer.json, when the line is already present in analog's composer.json. Composer fetches all dependecies and sub-dependencies
by itself
