### PR TITLE
Make flush() a static function to agree with call in init()

### DIFF
--- a/lib/Analog/Handler/LevelBuffer.php
+++ b/lib/Analog/Handler/LevelBuffer.php
@@ -56,7 +56,7 @@ class LevelBuffer {
 	/**
 	 * Passes the buffered log to the final $handler.
 	 */
-	public function flush () {
+	public static function flush () {
 		$handler = self::$handler;
 		return $handler (self::$buffer, true);
 	}


### PR DESCRIPTION
Initialization of LevelBuffer throws an error because LevelBuffer::flush() expects a static function, but flush is declared non-static
