### PR TITLE
Updated syslog.php to include full set of levels

### DIFF
--- a/lib/Analog/Handler/Syslog.php
+++ b/lib/Analog/Handler/Syslog.php
@@ -14,10 +14,12 @@ class Syslog {
 	public static $levels = array (
 		\Analog\Analog::DEBUG    => LOG_DEBUG,
 		\Analog\Analog::INFO     => LOG_INFO,
+		\Analog\Analog::NOTICE   => LOG_NOTICE,
 		\Analog\Analog::WARNING  => LOG_WARNING,
 		\Analog\Analog::ERROR    => LOG_ERR,
 		\Analog\Analog::CRITICAL => LOG_CRIT,
-		\Analog\Analog::ALERT    => LOG_ALERT
+		\Analog\Analog::ALERT    => LOG_ALERT,
+		\Analog\Analog::URGENT   => LOG_EMERG
 	);
 
 	public static $facilities = array (


### PR DESCRIPTION
PHP has constants for these levels yet Analog doesn't use them in the Syslog handler.
