### PR TITLE
Update mail.php

### DIFF
--- a/lib/Analog/Handler/Mail.php
+++ b/lib/Analog/Handler/Mail.php
@@ -16,6 +16,7 @@ namespace Analog\Handler;
 class Mail {
 	public static function init ($to, $subject, $from) {
 		return function ($info, $buffered = false) use ($to, $subject, $from) {
+			if($info=="") return; // do not send empty mail.
 			$headers = sprintf ("From: %s\r\nContent-type: text/plain; charset=utf-8\r\n", $from);
 			$body = ($buffered)
 				? "Logged:\n" . $info


### PR DESCRIPTION
When using the Mail log handler, every time the Mail class is destroyed, it will send an empty email with an empty log. this results in an email for "every" request.  I have added a check to make sure that the if the $info is empty dont send an empty email.
