### PR TITLE
replace Mongo class (deprecated) with MongoClient class

### DIFF
--- a/examples/mongo.php
+++ b/examples/mongo.php
@@ -11,7 +11,7 @@ Analog::handler (Analog\Handler\Mongo::init (
 Analog::log ('Error message');
 Analog::log ('Debug info', Analog::DEBUG);
 
-$m = new Mongo ('localhost:27017');
+$m = new MongoClient ('mongodb://localhost:27017');
 $cur = $m->testing->log->find ();
 foreach ($cur as $doc) {
 	print_r ($doc);

--- a/lib/Analog/Handler/Mongo.php
+++ b/lib/Analog/Handler/Mongo.php
@@ -17,7 +17,7 @@ namespace Analog\Handler;
  * Alternately, if you have an existing Mongo connection,
  * you can simply initialize it with that:
  *
- *     $conn = new Mongo ('localhost:27017');
+ *     $conn = new MongoClient ('localhost:27017');
  *     Analog::handler (Analog\Handler\Mongo::init (
  *         $conn,  // Mongo object
  *         'mydb', // database name
@@ -26,10 +26,10 @@ namespace Analog\Handler;
  */
 class Mongo {
 	public static function init ($server, $database, $collection) {
-		if ($server instanceof \Mongo) {
+		if ($server instanceof \MongoClient) {
 			$db = $server->{$database};
 		} else {
-			$conn = new \Mongo ($server);
+			$conn = new \MongoClient ("mongodb://$server");
 			$db = $conn->{$database};
 		}
 		return function ($info) use ($db, $collection) {


### PR DESCRIPTION
According to the [MongoDB driver documentation](http://php.net/manual/en/class.mongo.php) the Mongo class is deprecated:

**Warning** This class has been DEPRECATED as of version 1.3.0. Relying on this feature is highly discouraged. Please use MongoClient instead.
