### PR TITLE
use new mongodb driver (if available) instead of the legacy driver

### DIFF
--- a/lib/Analog/Handler/Mongo.php
+++ b/lib/Analog/Handler/Mongo.php
@@ -17,7 +17,8 @@ namespace Analog\Handler;
  * Alternately, if you have an existing Mongo connection,
  * you can simply initialize it with that:
  *
- *     $conn = new MongoClient ('localhost:27017');
+ *     $conn = new MongoClient ('localhost:27017');           // mongo driver
+ *     $conn = new MongoDB\Driver\Manager('localhost:27017'); // mongodb driver
  *     Analog::handler (Analog\Handler\Mongo::init (
  *         $conn,  // Mongo object
  *         'mydb', // database name


### PR DESCRIPTION
The mongo driver is superseded by the new mongodb driver. The legacy driver is not compatible with PHP 7.
This change allows the Mongo Handler to use the new driver, if available.