### PR TITLE
Delay setting the handler in Logger so each Logger can have its own handler

### DIFF
--- a/lib/Analog/Logger.php
+++ b/lib/Analog/Logger.php
@@ -52,6 +52,8 @@ use Psr\Log\InvalidArgumentException;
  * @author Johnny Broadway
  */
 class Logger implements LoggerInterface {
+	private $handler = null;
+
 	/**
 	 * Converts from PSR-3 log levels to Analog log levels.
 	 */
@@ -130,7 +132,7 @@ class Logger implements LoggerInterface {
 	 * Sets the Analog log handler.
 	 */
 	public function handler ($handler) {
-		Analog::handler ($handler);
+		$this->handler = $handler;
 	}
 
 	/**
@@ -212,6 +214,10 @@ class Logger implements LoggerInterface {
 	 * Perform the logging to Analog after the log level has been converted.
 	 */
 	private function _log ($level, $message, $context) {
+		if ($this->handler != null) {
+			Analog::handler ($this->handler);
+		}
+
 		Analog::log (
 			$this->interpolate ($message, $context),
 			$level


### PR DESCRIPTION
Each Logger instance stores its handler and switches the handler used by Analog before logging, which I think might solve #49 with minimal changes.

Example usage:

```php
<?php

require 'vendor/autoload.php';

use Analog\Logger;
use Analog\Handler;

$log1 = '';
$log2 = '';

$logger1 = new Logger ();
$logger1->handler (Handler\Variable::init ($log1));

$logger2 = new Logger ();
$logger2->handler (Handler\Variable::init ($log2));

$logger1->debug ('Log 1.1');
$logger2->debug ('Log 2.1');

$logger1->debug ('Log 1.2');
$logger2->debug ('Log 2.2');

$logger1->debug ('Log 1.3');
$logger2->debug ('Log 2.3');

echo $log1;
echo '---' . PHP_EOL;
echo $log2;
```