### PR TITLE
Fixes support for nested loggers when using multiple Logger instances

### DIFF
--- a/lib/Analog/Analog.php
+++ b/lib/Analog/Analog.php
@@ -174,6 +174,10 @@ class Analog {
 		$handler = self::handler ();
 
 		if (! $handler instanceof \Closure) {
+			if (is_object ($handler) && method_exists ($handler, 'log')) {
+				return $handler->log ($struct);
+			}
+
 			$handler = \Analog\Handler\File::init ($handler);
 		}
 		return $handler ($struct);

--- a/lib/Analog/Handler/Buffer.php
+++ b/lib/Analog/Handler/Buffer.php
@@ -21,40 +21,12 @@ namespace Analog\Handler;
  * to the buffer.
  */
 class Buffer {
-	/**
-	 * This builds a log string of all messages logged.
-	 */
-	public static $buffer = '';
-
-	/**
-	 * This contains the handler to send to on close.
-	 */
-	private static $handler;
-
-	/**
-	 * A copy of our destructor object that will call close() on our behalf,
-	 * since static classes can't have their own __destruct() methods.
-	 */
-	private static $destructor;
 
 	/**
 	 * Accepts another handler function to be used on close().
 	 */
 	public static function init ($handler) {
-		self::$handler = $handler;
-		self::$destructor = new \Analog\Handler\Buffer\Destructor ();
-
-		return function ($info) {
-			Buffer::$buffer .= vsprintf (\Analog\Analog::$format, $info);
-		};
-	}
-
-	/**
-	 * Passes the buffered log to the final $handler.
-	 */
-	public static function close () {
-		$handler = self::$handler;
-		return $handler (self::$buffer, true);
+		return new Buffer ($handler);
 	}
 
 	/**

--- a/lib/Analog/Handler/Buffer.php
+++ b/lib/Analog/Handler/Buffer.php
@@ -56,4 +56,22 @@ class Buffer {
 		$handler = self::$handler;
 		return $handler (self::$buffer, true);
 	}
+
+	/**
+	 * For use as a class instance
+	 */
+	private $_handler;
+	private $_buffer = '';
+	
+	public function __construct ($handler) {
+		$this->_handler = $handler;
+	}
+
+	public function log ($info) {
+		$this->_buffer .= vsprintf (\Analog\Analog::$format, $info);
+	}
+
+	public function __destruct () {
+		call_user_func ($this->_handler, $this->_buffer, true);
+	}
 }

--- a/lib/Analog/Handler/LevelBuffer.php
+++ b/lib/Analog/Handler/LevelBuffer.php
@@ -26,39 +26,13 @@ namespace Analog\Handler;
  * to the buffer.
  */
 class LevelBuffer {
-	/**
-	 * This builds a log string of all messages logged.
-	 */
-	public static $buffer = '';
-
-	/**
-	 * This contains the handler to send to on close.
-	 */
-	private static $handler;
 
 	/**
 	 * Accepts another handler function to be used on close().
 	 * $until_level defaults to CRITICAL.
 	 */
 	public static function init ($handler, $until_level = 2) {
-		self::$handler = $handler;
-
-		return function ($info) use ($until_level) {
-			LevelBuffer::$buffer .= vsprintf (\Analog\Analog::$format, $info);
-			if ($info['level'] <= $until_level) {
-				// flush and reset the buffer
-				LevelBuffer::flush ();
-				LevelBuffer::$buffer = '';
-			}
-		};
-	}
-
-	/**
-	 * Passes the buffered log to the final $handler.
-	 */
-	public static function flush () {
-		$handler = self::$handler;
-		return $handler (self::$buffer, true);
+		return new LevelBuffer ($handler, $until_level);
 	}
 
 	/**

--- a/lib/Analog/Handler/LevelBuffer.php
+++ b/lib/Analog/Handler/LevelBuffer.php
@@ -60,4 +60,25 @@ class LevelBuffer {
 		$handler = self::$handler;
 		return $handler (self::$buffer, true);
 	}
+
+	/**
+	 * For use as a class instance
+	 */
+	private $_handler;
+	private $_until_level = 2;
+	private $_buffer = '';
+
+	public function __construct ($handler, $until_level = 2) {
+		$this->_handler = $handler;
+		$this->_until_level = $until_level;
+	}
+
+	public function log ($info) {
+		$this->_buffer .= vsprintf (\Analog\Analog::$format, $info);
+		if ($info['level'] <= $this->_until_level) {
+			// flush and reset the buffer
+			call_user_func ($this->_handler, $this->_buffer, true);
+			$this->_buffer = '';
+		}
+	}
 }

--- a/lib/Analog/Handler/LevelName.php
+++ b/lib/Analog/Handler/LevelName.php
@@ -30,21 +30,8 @@ class LevelName {
 		\Analog\Analog::URGENT   => 'URGENT'
 	);
 
-	/**
-	 * This contains the handler to send to
-	 */
-	public static $handler;
-
 	public static function init ($handler) {
-		self::$handler = $handler;
-
-		return function ($info) {
-			if (isset(self::$log_levels[$info['level']])) {
-				$info['level'] = self::$log_levels[$info['level']];
-			}
-			$handler = LevelName::$handler;
-			$handler ($info);
-		};
+		return new LevelName ($handler);
 	}
 
 	/**

--- a/lib/Analog/Handler/LevelName.php
+++ b/lib/Analog/Handler/LevelName.php
@@ -47,4 +47,16 @@ class LevelName {
 		};
 	}
 
+	private $_handler;
+
+	public function __construct ($handler) {
+		$this->_handler = $handler;
+	}
+
+	public function log ($info) {
+		if (isset(self::$log_levels[$info['level']])) {
+			$info['level'] = self::$log_levels[$info['level']];
+		}
+		call_user_func ($this->_handler, $info);
+	}
 }

--- a/lib/Analog/Handler/LevelName.php
+++ b/lib/Analog/Handler/LevelName.php
@@ -47,6 +47,9 @@ class LevelName {
 		};
 	}
 
+	/**
+	 * For use as a class instance
+	 */
 	private $_handler;
 
 	public function __construct ($handler) {

--- a/lib/Analog/Handler/Multi.php
+++ b/lib/Analog/Handler/Multi.php
@@ -52,4 +52,29 @@ class Multi {
 			}
 		};
 	}
+
+	/**
+	 * For use as a class instance
+	 */
+	private $_handlers;
+
+	public function __construct ($handlers) {
+		$this->_handlers = $handlers;
+	}
+
+	public function log ($info) {
+		$level = is_numeric ($info['level']) ? $info['level'] : 3;
+		while ($level <= 7) {
+			if (isset ($this->_handlers[$level])) {
+				if (! is_array ($this->_handlers[$level])) {
+					$this->_handlers[$level] = array ($this->_handlers[$level]);
+				}
+
+				foreach ($this->_handlers[$level] as $handler) {
+					$handler ($info);
+				}
+			}
+			$level++;
+		}
+	}
 }

--- a/lib/Analog/Handler/Multi.php
+++ b/lib/Analog/Handler/Multi.php
@@ -33,24 +33,7 @@ namespace Analog\Handler;
  */
 class Multi {
 	public static function init ($handlers) {
-		return function ($info) use ($handlers) {
-			$level = is_numeric ($info['level']) ? $info['level'] : 3;
-			while ($level <= 7) {
-				if ( isset ( $handlers[ $level ] ) ) {
-
-					if ( ! is_array( $handlers[ $level ] ) ) {
-						$handlers[ $level ] = array( $handlers[ $level ] );
-					}
-
-					foreach ( $handlers[ $level ] as $handler ) {
-						$handler( $info );
-					}
-
-					return;
-				}
-				$level++;
-			}
-		};
+		return new Multi ($handlers);
 	}
 
 	/**

--- a/lib/Analog/Handler/Threshold.php
+++ b/lib/Analog/Handler/Threshold.php
@@ -22,24 +22,13 @@ namespace Analog\Handler;
  * to the buffer.
  */
 class Threshold {
-	/**
-	 * This contains the handler to send to on close.
-	 */
-	public static $handler;
 
 	/**
 	 * Accepts another handler function to be used on close().
 	 * $until_level defaults to ERROR.
 	 */
 	public static function init ($handler, $until_level = 3) {
-		self::$handler = $handler;
-
-		return function ($info) use ($until_level) {
-			if ($info['level'] <= $until_level) {
-				$handler = Threshold::$handler;
-				$handler ($info);
-			}
-		};
+		return new Threshold ($handler, $until_level);
 	}
 
 	/**
@@ -54,7 +43,7 @@ class Threshold {
 	}
 
 	public function log ($info) {
-		if ($inf['level'] <= $this->_until_level) {
+		if ($info['level'] <= $this->_until_level) {
 			call_user_func ($this->_handler, $info);
 		}
 	}

--- a/lib/Analog/Handler/Threshold.php
+++ b/lib/Analog/Handler/Threshold.php
@@ -42,4 +42,20 @@ class Threshold {
 		};
 	}
 
+	/**
+	 * For use as a class instance
+	 */
+	private $_handler;
+	private $_until_level = 3;
+
+	public function __construct ($handler, $until_level = 3) {
+		$this->_handler = $handler;
+		$this->_until_level = $until_level;
+	}
+
+	public function log ($info) {
+		if ($inf['level'] <= $this->_until_level) {
+			call_user_func ($this->_handler, $info);
+		}
+	}
 }


### PR DESCRIPTION
This ought to make it possible to support nested loggers with multiple Logger instances, fixing #49.

Usage is slightly different, where now instead of each handler being a static `::init()` call, we instantiate the handler via `new Handler\LevelBuffer()` at the first level and Analog should take care of the rest.

```php
<?php

require 'vendor/autoload.php';

use Analog\Logger;
use Analog\Handler;

$log1 = '';
$log2 = '';

$logger1 = new Logger ();
$logger1->handler (new Analog\Handler\LevelName (
	Handler\Variable::init ($log1)
));

$logger2 = new Logger ();
$logger2->handler (new Analog\Handler\LevelBuffer (
	Handler\Variable::init ($log2),
	Analog::ERROR
));

$logger1->debug ('Log 1.1');
$logger2->debug ('Log 2.1');

$logger1->debug ('Log 1.2');
$logger2->debug ('Log 2.2');

$logger1->debug ('Log 1.3');
$logger2->error ('Log 2.3');

echo $log1;
echo '---' . PHP_EOL;
echo $log2;
```